### PR TITLE
chore(back): add .gitignore for Python/Django project

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,46 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+
+# Ignorar bases de datos
+*.db
+*.sqlite
+*.sqlite3
+
+
+# Directorios de Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.so
+
+# Entorno virtual
+.env/
+venv/
+env/
+/Lib/
+/Scripts/
+/Include/
+.python-version
+
+# Archivos de bases de datos
+*.db
+*.sqlite
+*.sqlite3
+
+# Archivos de IDE (JetBrains)
+.idea/
+*.iml
+*.iws
+*.ipr
+
+# Archivos de logs y datos temporales
+*.log
+/data/
+
+# Archivos específicos de sistema operativo
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
- Exclude __pycache__ directories
- Ignore virtual environment folders (venv, env)
- Exclude database files (.sqlite3, .db)
- Ignore environment variables files (.env)
- Exclude Python compiled files (.pyc, .pyo)
- Add IDE/editor specific exclusions (vscode, pycharm)